### PR TITLE
Setting for specifying font (path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ overlay_save_folder: overlays/
     # PATTRMM will ATTEMPT to create it.
     # Default location is the default PMM 'overlays' folder and does not need specified.
 
+font_path: fonts/Juventus-Fans-Bold.ttf
+    # Specify a path to a font file to use for the overlays. Your PMM config folder
+    # (where your config.yml is), will always be the BASE location.
+    # Default font path is 'fonts/Juventus-Fans-Bold.ttf' and does not need specified.
+
 trakt_list_privacy: private
     # Specify public/private trakt list privacy for returning soon list. Can be set per library.
     # Default is private and does not need specified.

--- a/pattrmm.py
+++ b/pattrmm.py
@@ -95,6 +95,7 @@ libraries:
     trakt_list_privacy: private
     save_folder: "metadata/"
     overlay_save_folder: "overlays/"
+    font_path: "fonts/Juventus-Fans-Bold.ttf"
     refresh: 30                      # Full-refresh delay for library          
     days_ahead: 30                   # How far ahead to consider 'Returning Soon'
     extensions:
@@ -920,6 +921,12 @@ def librarySetting(library, value):
                     entry = pref['libraries'][library]['overlay_save_folder']
                 except KeyError:
                     entry = 'overlays/'
+            
+            if value == 'font_path':
+                try:
+                    entry = pref['libraries'][library]['font_path']
+                except KeyError:
+                    entry = 'fonts/Juventus-Fans-Bold.ttf'
 
             if value == 'trakt_list_privacy':
                 try:
@@ -1486,6 +1493,9 @@ for library in loaded_settings_yaml['libraries']:
     # overlay template path
     rs_overlay_template_file = "./preferences/" + library_clean_path + "-status-template.yml"
     
+    # font file path (font folder and font file)
+    rs_overlay_font_path = vars.librarySetting(library, 'font_path')
+    
 
     # Just some information
     print("Checking folder structure for " + library + ".")
@@ -1603,7 +1613,7 @@ templates:
       horizontal_align: <<horizontal_align>>
       vertical_offset: <<vertical_offset>>
       vertical_align: <<vertical_align>>
-      font: config/fonts/Juventus-Fans-Bold.ttf
+      font: config/{rs_overlay_font_path}
       font_size: <<font_size>>
       font_color: <<color>>
       group: <<group>>

--- a/vars.py
+++ b/vars.py
@@ -747,6 +747,12 @@ def librarySetting(library, value):
                     entry = pref['libraries'][library]['save_folder']
                 except KeyError:
                     entry = ''
+            
+            if value == 'font_path':
+                try:
+                    entry = pref['libraries'][library]['font_path']
+                except KeyError:
+                    entry = 'fonts/Juventus-Fans-Bold.ttf'
 
             if value == 'overlay_save_folder':
                 try:


### PR DESCRIPTION
Regarding #52 

Added the ability to specify a font path. Usefull if the font files are not stored in config/fonts/ and allows the use of other fonts.

Changes
- updated vars.py
- updated pattrmm.py
- updated README